### PR TITLE
Fix all but one compiler warnings

### DIFF
--- a/src/pico_ql_erb_templates/pico_ql_directives_utils.erb
+++ b/src/pico_ql_erb_templates/pico_ql_directives_utils.erb
@@ -182,6 +182,7 @@ int get_datastructure_size(sqlite3_vtab_cursor *cur) {
         <%= @tables[vt].signature.chomp('*') %> container_instance;
         forward_container_concept_check(container_instance);
         forward_iterator_concept_class<<%= @tables[vt].signature.chomp('*') %>::iterator> it;
+	(void)it;	// Silence compiler unised variable warning
 <%# stc->source will definitely hold a pointer so retyping the signature as
 <%# follows is correct. %>
         <%= @tables[vt].signature %><%= retype %> any_dstr = (<%= @tables[vt].signature %><%= retype %>)stc->source;
@@ -230,7 +231,7 @@ int init_text_vector(stlTableCursor *stc) {
  */
 int deinit_text_vector(stlTableCursor *stc) {
   vector<string*> *tr = (vector<string*> *)stc->textResults;
-  for (int i = 0; i<tr->size(); i++)
+  for (size_t i = 0; i<tr->size(); i++)
       delete tr->at(i);
   delete tr;
 }

--- a/src/pico_ql_erb_templates/pico_ql_pre_search.erb
+++ b/src/pico_ql_erb_templates/pico_ql_pre_search.erb
@@ -1,6 +1,7 @@
 // Filters column values of virtual table <%= @name %>.
 int <%= @name %>_search(sqlite3_vtab_cursor *cur, char *constr, sqlite3_value *val) {
     stlTable *stl = (stlTable *)cur->pVtab;
+    (void)stl;	// Silence compiler unused variable warning
     stlTableCursor *stcsr = (stlTableCursor *)cur;
 <%      if @base_var.length > 0 %>
     if (stcsr->isInstanceNULL) {   // Size 1 to print "(null)".


### PR DESCRIPTION
For the one remaining, are you sure you need the `i = 0` in the following?

``` c
int op, iCol, i = 0, count = 0, re = 0;
```
