### PR TITLE
Examples/CApp: Char buffer was too small for one of the SQL queries.

### DIFF
--- a/examples/CApp/pico_ql_test_cpp.cpp
+++ b/examples/CApp/pico_ql_test_cpp.cpp
@@ -40,7 +40,7 @@ int exec_tests() {
   fs.open("cppapp_test_current.txt", fstream::out);
 
   int i = 0;
-  char q[200];
+  char q[256];
 
   strcpy(q, "select nCurrency, rownum, name, price_mode, price, weight_mode, weight from MonetarySystem JOIN Money ON Money.base = MonetarySystem.currency;");
   fs << "Query " << i++ << ":\n " << q << endl << endl;


### PR DESCRIPTION
Hey Marios,

I stumbled upon your project which seems perfect for adding SQL querying to the internal state of my molecular dynamics software package molecuilder.
I made some smaller enhancements: this is the first with just a tiny overflow fix.

Kind regards,

Frederik